### PR TITLE
typo fix

### DIFF
--- a/slides/index.Rmd
+++ b/slides/index.Rmd
@@ -751,7 +751,7 @@ In the past 12 months:
 - Monash University Business School now recognises software as first class academic output
 - Statistical Society of Australia (SSA) hosted a panel session on RSEs
 - ACEMs podcast: acknowledging research software
-- I delievered seminar: ["Acknowledging research software in academia"]() at UNSW
+- I delivered seminar: ["Acknowledging research software in academia"]() at UNSW
 - SSA has developed two awards for statistical software:
   - Di Cook Award ($1000): Student prize for Victoria and Tasmania
   - Venables Award ($5000): National statistical software prize


### PR DESCRIPTION
Great deck!

Another small (tiny!) thing I've noticed is that because you're using `.large[` instead of increasing the size via CSS, the title looks like this on the browser tab:

![image](https://user-images.githubusercontent.com/8360597/175477434-c160db81-f480-426d-9d12-4cfd08c48a44.png)
